### PR TITLE
Add DConverter - free developer and business tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A collection of neat and small helpers for creating stuff online. Handle with ca
 ### Code Formatting (JSON, SQL, CSV, YAML)
 - CSV and SQL to JSON, JSON validator & beautifier: [csvjson](https://www.csvjson.com/)
 - Validating, beautifying, converting and a ton more on [codebeautify.org](https://codebeautify.org/)
+- Free all-in-one toolkit: JSON formatter, JWT decoder, regex tester, cron parser, invoice generator, EMI calculator, and 50+ more tools. No login required. [DConverter](https://www.dconverter.org)
 
 ### Code Formatting (Time)
 - Ruby Date/Time Formatting via [foragoodstrftime.com](https://www.foragoodstrftime.com/)


### PR DESCRIPTION
DConverter is a free, no-login, client-side toolkit with 30+ tools for developers and business users including JSON formatter, JWT decoder, regex tester, cron expression parser, invoice generator, and EMI calculator.

URL: https://www.dconverter.org
License: Free
Platform: Web